### PR TITLE
namedpipe/datagramme encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,12 @@ from xp_named_pipes import NamedPipe, ReadPipeEnd, WritePipeEnd
 with WritePipeEnd("pipe/path") as my_pipe_end:
   my_pipe_end.write(b"My Data")
 ```
+
+## Testing
+
+Rudimentary testing is performed by pythons `unittest` module. To run the tests
+the following command can be used from the root of this repository:
+
+```bash
+python3 -m unittest ./tests/test_*
+```

--- a/README.md
+++ b/README.md
@@ -134,6 +134,33 @@ with WritePipeEnd("pipe/path") as my_pipe_end:
   my_pipe_end.write(b"My Data")
 ```
 
+## Encoded Datagramme Support
+
+The cross platform pipes transfer bytes and the usage of those bytes to
+transfer meaningful messages is up to the user. Some operating systems might
+not guarantee a complete write (including a flush of possible buffers) on
+write. To ease the use to transfer entire messages in a controlled manner the
+class `Base64DatagrammeEncoderDecoder` provides an easy way to encode messages
+as a `datagramme`. A `datagramme` is the message encoded as Base64 and an
+appended delimiter byte `0x00` to delimit individual `datagramme`s. The
+`Base64DatagrammeEncoderDecoder` ensures that each `write` corresponds to a
+single `read` operation and takes care of handling incomplete transfers of
+`datagramme`s by buffering them transparently in an internal buffer.
+
+```Python
+from xp_named_pipe import NamedPipe, ReadPipeEnd, WritePipeEnd
+from xp_named_pipe.base64_encoder_decoder import Base64DatagrammeEncoderDecoder as B64
+
+with NamedPipe("pipe/path") as pipe:
+  with WritePipeEnd(pipe) as write_pipe_end:
+    b64_write = B64(
+        read_func=write_pipe_end.read(),
+        write_func=write_pipe_end.write(),
+    )
+
+    b64_write.write(b"This message is encoded and written to 'pipe/path' with a delimiter suffix")
+```
+
 ## Testing
 
 Rudimentary testing is performed by pythons `unittest` module. To run the tests

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Supported platforms:
 - [x] win32
 - [x] linux
 
-# API Description
+## API Description
 
 > [!NOTE]
 > Clone this repository into your project folder and import it from your
 > scripts reproduce the following examples.
 
-## NamedPipe
+### NamedPipe
 
 ```Python
 from xp_named_pipes import NamedPipe
@@ -42,7 +42,7 @@ if the underlying operating system might support bi-directional named pipes.
 > The prefix is handled transparent in this API, but the allocated system
 > resource will have the name: `<prefix>+<API_path>`
 
-### NamedPipe Resource State
+#### NamedPipe Resource State
 
 ```mermaid
 stateDiagram-v2
@@ -58,7 +58,7 @@ stateDiagram-v2
 - Resource allocation on the operating system is performed by calling `mkfifo()`.
 - Resource de-allocation on the operating system is performed by calling `unlink()`.
 
-## ReadPipeEnd & WritePipeEnd
+### ReadPipeEnd & WritePipeEnd
 
 ```Python
 from xp_named_pipes import NamedPipe, ReadPipeEnd, WritePipeEnd
@@ -100,41 +100,7 @@ stateDiagram-v2
   open --> close: close()
 ```
 
-## Context Management Protocol
-
-`NamedPipe`, `ReadPipeEnd` and `WritePipeEnd` support pythons context
-management protocol and can be used with the `with` statement.
-
-```Python
-from xp_named_pipes import NamedPipe, ReadPipeEnd, WritePipeEnd
-
-with NamedPipe("pipe/path") as my_pipe: # automatic (de)allocation of system resources
-  with ReadPipeEnd(my_pipe) as my_pipe_end: # automatic open/close of PipeEnd
-    print(my_pipe_end.read())
-```
-
-## Convenience PipeEnd Creation
-
-A `PipeEnd` (either `ReadPipeEnd` or `WritePipeEnd`) is created by specifying
-the `NamedPipe` for which the `PipeEnd` should be created. When a `PipeEnd` is
-created on a "client" side (which does not manage the system resources) it is
-not required to have access to the `NamedPipe` methods `mkfifo()` and
-`unlink()`.
-
-The `PipeEnd` can be created with a specification of the `NamedPipe` as a
-string instead of an instance of `class NamedPipe`. Operating system resources
-are not allocated and cannot be controlled in this context.
-
-`WritePipeEnd("path")` is equivalent to `WritePipeEnd(NamedPipe("path"))`.
-
-```Python
-from xp_named_pipes import NamedPipe, ReadPipeEnd, WritePipeEnd
-
-with WritePipeEnd("pipe/path") as my_pipe_end:
-  my_pipe_end.write(b"My Data")
-```
-
-## Encoded Datagramme Support
+### Encoded Datagramme Support
 
 The cross platform pipes transfer bytes and the usage of those bytes to
 transfer meaningful messages is up to the user. Some operating systems might
@@ -159,6 +125,40 @@ with NamedPipe("pipe/path") as pipe:
     )
 
     b64_write.write(b"This message is encoded and written to 'pipe/path' with a delimiter suffix")
+```
+
+### Context Management Protocol
+
+`NamedPipe`, `ReadPipeEnd` and `WritePipeEnd` support pythons context
+management protocol and can be used with the `with` statement.
+
+```Python
+from xp_named_pipes import NamedPipe, ReadPipeEnd, WritePipeEnd
+
+with NamedPipe("pipe/path") as my_pipe: # automatic (de)allocation of system resources
+  with ReadPipeEnd(my_pipe) as my_pipe_end: # automatic open/close of PipeEnd
+    print(my_pipe_end.read())
+```
+
+### Convenience PipeEnd Creation
+
+A `PipeEnd` (either `ReadPipeEnd` or `WritePipeEnd`) is created by specifying
+the `NamedPipe` for which the `PipeEnd` should be created. When a `PipeEnd` is
+created on a "client" side (which does not manage the system resources) it is
+not required to have access to the `NamedPipe` methods `mkfifo()` and
+`unlink()`.
+
+The `PipeEnd` can be created with a specification of the `NamedPipe` as a
+string instead of an instance of `class NamedPipe`. Operating system resources
+are not allocated and cannot be controlled in this context.
+
+`WritePipeEnd("path")` is equivalent to `WritePipeEnd(NamedPipe("path"))`.
+
+```Python
+from xp_named_pipes import NamedPipe, ReadPipeEnd, WritePipeEnd
+
+with WritePipeEnd("pipe/path") as my_pipe_end:
+  my_pipe_end.write(b"My Data")
 ```
 
 ## Testing

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+__package__ = "python_xp_named_pipe"

--- a/base64_encoder_decoder.py
+++ b/base64_encoder_decoder.py
@@ -1,0 +1,56 @@
+import base64
+
+from typing import Callable
+
+
+class Base64DatagrammeEncoderDecoder:
+    def __init__(
+        self,
+        read_func: Callable[[], bytearray],
+        write_func: Callable[[bytearray], None],
+    ) -> None:
+        self.read_func = read_func
+        self.write_func = write_func
+        self._datagrammes = []
+
+    def _datagrammes_fifo_put(self, datagramme: bytearray) -> None:
+        self._datagrammes.append(datagramme)
+
+    def _datagrammes_fifo_pop(self) -> bytearray:
+        return self._datagrammes.pop(0)
+
+    def _datagrammes_fifo_is_empty(self) -> bool:
+        if not self._datagrammes:
+            return True
+        else:
+            return False
+
+    def _set_partial_enc_datagramme(self, datagramme: bytearray) -> None:
+        self._partial_enc_datagramme = datagramme
+
+    def _pop_partial_enc_datagramme(self) -> bytearray:
+        partial_enc_datagramme = self._partial_enc_datagramme
+        self._set_partial_enc_datagramme(bytearray())
+        return partial_enc_datagramme
+
+    def _read_datagrammes_to_fifo(self) -> None:
+        data = self.read_func()
+        enc_datagrammes = (self._pop_partial_enc_datagramme() + data).split(b"\x00")
+
+        if not data.endswith(b"\x00"):
+            self._set_partial_enc_datagramme(enc_datagrammes[-1])
+            del enc_datagrammes[-1]
+
+        for enc_dg in enc_datagrammes:
+            dec_dg = bytearray(base64.b64decode(enc_dg.rstrip(b"\x00")))
+            self._datagrammes_fifo_put(dec_dg)
+        return None
+
+    def write(self, data: bytearray) -> None:
+        encoded_data = bytearray(base64.b64encode(data))
+        self.write_func(encoded_data + b"\x00")
+
+    def read(self) -> bytearray:
+        while self._datagrammes_fifo_is_empty():
+            self._read_datagrammes_to_fifo()
+        return self._datagrammes_fifo_pop()

--- a/base64_encoder_decoder.py
+++ b/base64_encoder_decoder.py
@@ -6,18 +6,18 @@ from typing import Callable
 class Base64DatagrammeEncoderDecoder:
     def __init__(
         self,
-        read_func: Callable[[], bytearray],
-        write_func: Callable[[bytearray], None],
+        read_func: Callable[[], bytes],
+        write_func: Callable[[bytes], None],
     ) -> None:
         self.read_func = read_func
         self.write_func = write_func
         self._datagrammes = []
         self._partial_enc_datagramme = bytes()
 
-    def _datagrammes_fifo_put(self, datagramme: bytearray) -> None:
+    def _datagrammes_fifo_put(self, datagramme: bytes) -> None:
         self._datagrammes.append(datagramme)
 
-    def _datagrammes_fifo_pop(self) -> bytearray:
+    def _datagrammes_fifo_pop(self) -> bytes:
         return self._datagrammes.pop(0)
 
     def _datagrammes_fifo_is_empty(self) -> bool:
@@ -26,12 +26,12 @@ class Base64DatagrammeEncoderDecoder:
         else:
             return False
 
-    def _set_partial_enc_datagramme(self, datagramme: bytearray) -> None:
+    def _set_partial_enc_datagramme(self, datagramme: bytes) -> None:
         self._partial_enc_datagramme = datagramme
 
-    def _pop_partial_enc_datagramme(self) -> bytearray:
+    def _pop_partial_enc_datagramme(self) -> bytes:
         partial_enc_datagramme = self._partial_enc_datagramme
-        self._set_partial_enc_datagramme(bytearray())
+        self._set_partial_enc_datagramme(bytes())
         return partial_enc_datagramme
 
     def _read_datagrammes_to_fifo(self) -> None:
@@ -43,15 +43,15 @@ class Base64DatagrammeEncoderDecoder:
             del enc_datagrammes[-1]
 
         for enc_dg in enc_datagrammes:
-            dec_dg = bytearray(base64.b64decode(enc_dg.rstrip(b"\x00")))
+            dec_dg = bytes(base64.b64decode(enc_dg.rstrip(b"\x00")))
             self._datagrammes_fifo_put(dec_dg)
         return None
 
-    def write(self, data: bytearray) -> None:
-        encoded_data = bytearray(base64.b64encode(data))
+    def write(self, data: bytes) -> None:
+        encoded_data = bytes(base64.b64encode(data))
         self.write_func(encoded_data + b"\x00")
 
-    def read(self) -> bytearray:
+    def read(self) -> bytes:
         while self._datagrammes_fifo_is_empty():
             self._read_datagrammes_to_fifo()
         return self._datagrammes_fifo_pop()

--- a/base64_encoder_decoder.py
+++ b/base64_encoder_decoder.py
@@ -12,6 +12,7 @@ class Base64DatagrammeEncoderDecoder:
         self.read_func = read_func
         self.write_func = write_func
         self._datagrammes = []
+        self._partial_enc_datagramme = bytes()
 
     def _datagrammes_fifo_put(self, datagramme: bytearray) -> None:
         self._datagrammes.append(datagramme)

--- a/tests/test_base64_encoder_decoder.py
+++ b/tests/test_base64_encoder_decoder.py
@@ -1,0 +1,40 @@
+from typing import assert_type
+import unittest
+import base64
+
+from base64_encoder_decoder import Base64DatagrammeEncoderDecoder as base64_end_dec
+
+
+class TestBase64DatagrammeEncoderDecoder(unittest.TestCase):
+    message_1 = b"Hello"
+    message_2 = b"World"
+    message_3 = b"and the rest of the universe."
+    message_1_enc = base64.b64encode(message_1)
+    message_2_enc = base64.b64encode(message_2)
+    message_3_enc = base64.b64encode(message_3)
+    delim = b"\x00"
+
+    def read_incomplete_datagramme(self) -> bytes:
+        return (
+            self.message_1_enc
+            + self.delim
+            + self.message_2_enc
+            + self.delim
+            + self.message_3_enc[0:2]
+        )
+
+    def write_mock(self, data: bytes) -> None:
+        return None
+
+    def test_incomplete_datagramme_detection(self):
+        b64 = base64_end_dec(self.read_incomplete_datagramme, self.write_mock)
+        message_1_actual = b64.read()
+        self.assertTrue(message_1_actual == self.message_1)
+        self.assertFalse(b64._datagrammes_fifo_is_empty())
+        self.assertTrue(b64._datagrammes[0] == self.message_2)
+        self.assertTrue(b64._partial_enc_datagramme == self.message_3_enc[0:2])
+        message_2_actual = b64.read()
+        self.assertTrue(message_2_actual == self.message_2)
+        self.assertTrue(b64._datagrammes_fifo_is_empty())
+        self.assertTrue(b64._partial_enc_datagramme == self.message_3_enc[0:2])
+        return

--- a/tests/test_xp_named_pipe.py
+++ b/tests/test_xp_named_pipe.py
@@ -1,0 +1,29 @@
+import unittest
+import os
+from xp_named_pipe import NamedPipe, WritePipeEnd, ReadPipeEnd
+
+
+class TestXpNamedPipe(unittest.TestCase):
+    test_pipe_path = "the_pipe"
+
+    def test_mkfifo_unlink(self):
+        pipe = NamedPipe(self.test_pipe_path)
+        print(pipe.get_path())
+        self.assertFalse(os.access(pipe.get_path(), os.F_OK))
+        pipe.mkfifo()
+        self.assertTrue(os.access(pipe.get_path(), os.F_OK))
+        pipe.unlink()
+        self.assertFalse(os.access(pipe.get_path(), os.F_OK))
+
+    def test_context_management_protocol(self):
+        pipe = NamedPipe(self.test_pipe_path)
+        self.assertFalse(os.access(pipe.get_path(), os.F_OK))
+
+        with NamedPipe(self.test_pipe_path) as pipe:
+            self.assertTrue(os.access(pipe.get_path(), os.F_OK))
+
+        self.assertFalse(os.path.exists(pipe.get_path()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_xp_named_pipe.py
+++ b/tests/test_xp_named_pipe.py
@@ -1,14 +1,18 @@
 import unittest
 import os
-from xp_named_pipe import NamedPipe, WritePipeEnd, ReadPipeEnd
+import sys
+import multiprocessing
+
+from time import sleep
+
+from xp_named_pipe import NamedPipe, ReadPipeEnd, WritePipeEnd
 
 
 class TestXpNamedPipe(unittest.TestCase):
-    test_pipe_path = "the_pipe"
+    test_pipe_path: str = "the_pipe"
 
     def test_mkfifo_unlink(self):
         pipe = NamedPipe(self.test_pipe_path)
-        print(pipe.get_path())
         self.assertFalse(os.access(pipe.get_path(), os.F_OK))
         pipe.mkfifo()
         self.assertTrue(os.access(pipe.get_path(), os.F_OK))
@@ -23,6 +27,40 @@ class TestXpNamedPipe(unittest.TestCase):
             self.assertTrue(os.access(pipe.get_path(), os.F_OK))
 
         self.assertFalse(os.path.exists(pipe.get_path()))
+
+
+class TestPipeEnd(unittest.TestCase):
+    test_pipe_path: str = "the_pipe7"
+    test_data: bytes = bytes(b"this is my data")
+
+    @staticmethod
+    def create_writer_process(send: bytes):
+        return multiprocessing.Process(target=TestPipeEnd.writer, args=(send,))
+
+    @staticmethod
+    def writer(send: bytes):
+
+        with NamedPipe(TestPipeEnd.test_pipe_path) as pipe:
+            with WritePipeEnd(pipe) as pipe_end:
+                pipe_end.write(TestPipeEnd.test_data)  # pyright: ignore
+
+        sys.exit(0)
+
+    def test_pipe_end(self):
+
+        writer = self.create_writer_process(self.test_data)
+        writer.start()
+
+        with ReadPipeEnd(NamedPipe(self.test_pipe_path)) as pipe_end:
+            read_data = pipe_end.read()  # pyright: ignore
+
+        writer.join(timeout=5)
+        if writer.is_alive():
+            writer.terminate()
+            self.fail("Writer process timed out")
+        self.assertEqual(writer.exitcode, 0)
+
+        self.assertTrue(read_data == self.test_data)
 
 
 if __name__ == "__main__":

--- a/xp_named_pipe.py
+++ b/xp_named_pipe.py
@@ -10,6 +10,5 @@ else:
     raise NotImplementedError
 
 NamedPipe = xpnp.NamedPipe
-# PipeEnd = xpnp.PipeEnd
 WritePipeEnd = xpnp.WritePipeEnd
 ReadPipeEnd = xpnp.ReadPipeEnd


### PR DESCRIPTION
- **add datagramme encoding and delimiter**
- **add unittest for NamedPipe**
- **add unittest for xp pipe ends**
- **add __init__.py for package naming**
- **add PipeEnd open() retry mechanism**
- **add Base64DatagrammeEncoderDecoder testcase for incomplete datagrammes**
- **add Base64DatagrammeEncoderDecoder testcase for write encoding and delimiter appending**
- **fix Base64DatagrammeEncoderDecoder init of incomplete datagramme storage**
- **fix Base64DatagrammeEncoderDecoder datatype from bytearray to bytes**
- **add readme testing hint**
- **add readme encoded datagramme support section**
- **fix readme heading level**
